### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/lib/verbose.js
+++ b/lib/verbose.js
@@ -64,14 +64,22 @@ module.exports.log = function () {
     logs.push('[' + Date.now() + '][VERBOSE]');
     for (var i in arguments) {
         var arg = arguments[i];
+        var out;
         if (arg && typeof arg === 'object') {
-            // Stringify the redacted object for safe output
-            logs.push(JSON.stringify(redactSensitive(arg)));
+            // Handle plain object, array, or other objects
+            try {
+                out = JSON.stringify(redactSensitive(arg));
+            } catch (e) {
+                // fallback for objects that can't be stringified
+                out = '[Unserializable Object]';
+            }
         } else if (typeof arg === 'string') {
-            logs.push(redactStringSensitive(arg));
+            out = redactStringSensitive(arg);
         } else {
-            logs.push(arg);
+            // For all other primitives, convert to string and redact
+            out = redactStringSensitive(String(arg));
         }
+        logs.push(out);
     }
     console.log.apply(console, logs);
 };


### PR DESCRIPTION
Potential fix for [https://github.com/BonnierNews/in-app-purchase/security/code-scanning/3](https://github.com/BonnierNews/in-app-purchase/security/code-scanning/3)

To fully mitigate the risk of logging sensitive data in clear text, the log function should explicitly sanitize *any* input argument, not just plain objects and strings. For all arguments, regardless of type, any sensitive data (matching the list of sensitive field names) should be redacted before logging. The best approach is to apply redaction to all arguments: recursively redact objects (of any class/constructor); for strings, perform pattern replacement; and for primitives, ensure no sensitive value slips through by converting to string and then passing through the string redactor. For arrays, each element should be redacted properly. Additionally, consider cases where a function or other type is passed as a log argument. In such cases, convert to string and apply string redaction.  
**Required changes**:  
- Edit the log function to process every argument, regardless of type, by converting to a string if necessary, and applying string-sensitive redaction.
- Modify the object redaction so that non-plain objects (including arrays and custom objects) are also handled safely.
- Do not log objects, functions, buffers, etc., in a way that could expose internal fields; always pass them through a string/redaction pipeline first.
- No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
